### PR TITLE
Bug #13711 - ftp filemask does not validate if mask is valid

### DIFF
--- a/freenas/cli/output/__init__.py
+++ b/freenas/cli/output/__init__.py
@@ -351,6 +351,10 @@ def read_value(value, tv=ValueType.STRING):
     if tv == ValueType.PERMISSIONS:
         if isinstance(value, str):
             value = string_to_int(value)
+        else:
+            if value > 0o777:
+                raise ValueError('Invalid permissions format - use octal notation with maximum value of 0o777')
+
         return get_unix_permissions(value)
 
     if tv == ValueType.PASSWORD:

--- a/freenas/cli/plugins/service.py
+++ b/freenas/cli/plugins/service.py
@@ -1008,13 +1008,13 @@ class FTPNamespace(NestedEntityMixin, ItemNamespace):
         )
         self.add_property(
             descr='File creation mask',
-            name='filemask',
+            name='file_creation_mask',
             get='filemask',
             type=ValueType.PERMISSIONS
         )
         self.add_property(
             descr='Directory creation mask',
-            name='dirmask',
+            name='directory_creation_mask',
             get='dirmask',
             type=ValueType.PERMISSIONS
         )


### PR DESCRIPTION
This is the best what can be done without changing the CLI parser 